### PR TITLE
set LIBSPDM_DEBUG_LIBSPDM_ASSERT_CONFIG=0 to avoid ASSERT_DEADLOOP.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,15 +76,16 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -E env CFLAGS="${{ matrix.configurations }}" cmake -DARCH=${{ matrix.arch }} -DTOOLCHAIN=${{ matrix.toolchain }} -DTARGET=${{ matrix.target }} -DCRYPTO=${{ matrix.crypto }} ..
+          cmake -E env CFLAGS="${{ matrix.configurations }} -DLIBSPDM_DEBUG_LIBSPDM_ASSERT_CONFIG=0" cmake -DARCH=${{ matrix.arch }} -DTOOLCHAIN=${{ matrix.toolchain }} -DTARGET=${{ matrix.target }} -DCRYPTO=${{ matrix.crypto }} ..
           make copy_sample_key
+          make copy_seed
           make -j`nproc`
       - name: Build - Windows
         if: matrix.os == 'windows-latest'
         run: |
           mkdir build
           cd build
-          cmake -E env CFLAGS="${{ matrix.configurations }}" cmake -G"NMake Makefiles" -DARCH=${{ matrix.arch }} -DTOOLCHAIN=${{ matrix.toolchain }} -DTARGET=${{ matrix.target }} -DCRYPTO=${{ matrix.crypto }} ..
+          cmake -E env CFLAGS="${{ matrix.configurations }} -DLIBSPDM_DEBUG_LIBSPDM_ASSERT_CONFIG=0" cmake -G"NMake Makefiles" -DARCH=${{ matrix.arch }} -DTOOLCHAIN=${{ matrix.toolchain }} -DTARGET=${{ matrix.target }} -DCRYPTO=${{ matrix.crypto }} ..
           nmake copy_sample_key
           nmake
 
@@ -96,3 +97,8 @@ jobs:
         run: |
           cd build/bin
           ./test_spdm_responder
+      - name: Test with initial seed
+        if: matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'
+        run: |
+          cd build/bin
+          ./run_initial_seed.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,22 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
                        COMMAND xcopy /y /s ${SRC} ${DEST})
 endif()
 
+ADD_CUSTOM_TARGET(copy_seed)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    ADD_CUSTOM_COMMAND(TARGET copy_seed
+                    PRE_BUILD
+                    COMMAND cp -r -f ${LIBSPDM_DIR}/unit_test/fuzzing/seeds ${EXECUTABLE_OUTPUT_PATH}
+                    COMMAND cp -r -f ${LIBSPDM_DIR}/unit_test/fuzzing/run_initial_seed.sh ${EXECUTABLE_OUTPUT_PATH})
+elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
+    STRING(REPLACE "/" "\\" SRC ${LIBSPDM_DIR}/unit_test/fuzzing/seeds)
+    STRING(REPLACE "/" "\\" DEST ${EXECUTABLE_OUTPUT_PATH})
+
+    ADD_CUSTOM_COMMAND(TARGET copy_seed
+                       PRE_BUILD
+                       COMMAND xcopy /y /s ${SRC} ${DEST})
+endif()
+
 if(CRYPTO STREQUAL "mbedtls")
     ADD_SUBDIRECTORY(os_stub/cryptlib_mbedtls)
 elseif(CRYPTO STREQUAL "openssl")


### PR DESCRIPTION
Get the test result by checking the return value of test program.
Add a new command 'copy_seed' to copy the seed files.
Enable the basic test with initial seed.

Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>